### PR TITLE
metadata.json: Add support for GNOME 42

### DIFF
--- a/toggle-night-light@cansozbir.github.io/metadata.json
+++ b/toggle-night-light@cansozbir.github.io/metadata.json
@@ -5,7 +5,8 @@
         "3.36",
         "3.38",
         "40",
-        "41"
+        "41",
+        "42"
     ],
     "url": "https://github.com/cansozbir/gnome-shell-toggle-night-light-extension",
     "uuid": "toggle-night-light@cansozbir.github.io",


### PR DESCRIPTION
This extension works on GNOME 42 out of the box, we just need to declare that and add 42 as a supported version.